### PR TITLE
Bugfix - authfile plugin did wrongly use username as IP and IP as use…

### DIFF
--- a/plugins/auth/authfile/acl.go
+++ b/plugins/auth/authfile/acl.go
@@ -19,5 +19,5 @@ func (a *aclAuth) CheckConnect(clientID, username, password string) bool {
 }
 
 func (a *aclAuth) CheckACL(action, clientID, username, ip, topic string) bool {
-	return checkTopicAuth(a.config, action, username, ip, clientID, topic)
+	return checkTopicAuth(a.config, action, ip, username, clientID, topic)
 }

--- a/plugins/auth/authfile/acl_test.go
+++ b/plugins/auth/authfile/acl_test.go
@@ -1,0 +1,23 @@
+//+build test
+
+package acl
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrigAcls(t *testing.T) {
+	pwd, _ := os.Getwd()
+	os.Chdir("../../../")
+	aclOrig := Init()
+	os.Chdir(pwd)
+
+	// rule: allow      ip          127.0.0.1      2         $SYS/#
+	origAllowed := aclOrig.CheckACL(PUB, "dummyClientID", "dummyUser", "127.0.0.1", "$SYS/something")
+	assert.True(t, origAllowed)
+	origAllowed = aclOrig.CheckACL(SUB, "dummyClientID", "dummyUser", "127.0.0.1", "$SYS/something")
+	assert.False(t, origAllowed)
+}


### PR DESCRIPTION
…rname in ACL checks (#100)

* adding test + fix issue with wrong order in acl check

* reduce to featureset from original fork